### PR TITLE
Add Install and Uninstall Scripts for GoCryptic

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,9 +27,16 @@ curl -L "$DOWNLOAD_URL" -o "$BINARY"
 # Make it executable
 chmod +x "$BINARY"
 
+# Determine if sudo is needed (skip if running as root)
+if [ "$EUID" -ne 0 ]; then
+    SUDO='sudo'
+else
+    SUDO=''
+fi
+
 # Move the binary to the install directory
 echo "Installing $BINARY to $INSTALL_DIR..."
-sudo mv "$BINARY" "$INSTALL_DIR"
+$SUDO mv "$BINARY" "$INSTALL_DIR"
 
 # Verify installation
 if command -v $BINARY &> /dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Set variables
+REPO="JonathanInTheClouds/gocryptic"
+VERSION="v1.0.0"
+BINARY="gocryptic"
+INSTALL_DIR="/usr/local/bin"
+
+# Detect OS
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+# Map `darwin` to `mac`, `linux` remains unchanged
+if [[ "$OS" == "darwin" ]]; then
+    OS="mac"
+elif [[ "$OS" != "linux" ]]; then
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+# Construct the download URL based on OS
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$BINARY-$OS"
+
+# Download the binary
+echo "Downloading $BINARY from $DOWNLOAD_URL..."
+curl -L "$DOWNLOAD_URL" -o "$BINARY"
+
+# Make it executable
+chmod +x "$BINARY"
+
+# Move the binary to the install directory
+echo "Installing $BINARY to $INSTALL_DIR..."
+sudo mv "$BINARY" "$INSTALL_DIR"
+
+# Verify installation
+if command -v $BINARY &> /dev/null; then
+    echo "$BINARY installed successfully!"
+else
+    echo "Installation failed."
+    exit 1
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Set variables
+BINARY="gocryptic"
+INSTALL_DIR="/usr/local/bin"
+
+# Check if the binary exists in the install directory
+if [ -f "$INSTALL_DIR/$BINARY" ]; then
+    echo "Removing $BINARY from $INSTALL_DIR..."
+    # Check if sudo is needed
+    if [ "$EUID" -ne 0 ]; then
+        sudo rm "$INSTALL_DIR/$BINARY"
+    else
+        rm "$INSTALL_DIR/$BINARY"
+    fi
+    echo "$BINARY uninstalled successfully!"
+else
+    echo "$BINARY not found in $INSTALL_DIR."
+fi


### PR DESCRIPTION
This pull request introduces new features to simplify the installation and uninstallation of GoCryptic, ensuring users can easily manage the tool on both Linux and macOS systems.

Changes Included:

    Install Script (install.sh):
        Automatically detects the user's operating system (Linux/macOS).
        Downloads the appropriate binary (gocryptic-linux or gocryptic-mac) from the GitHub releases page.
        Installs the binary into /usr/local/bin and makes it executable.
        Checks whether sudo is required and only uses it when necessary (i.e., when not running as root).
        Verifies the installation by checking that the binary is available in the system's PATH.

    Uninstall Script (uninstall.sh):
        Removes the GoCryptic binary from /usr/local/bin.
        Automatically detects whether sudo is needed for file removal (i.e., if the user is not running as root).
        Prints confirmation messages for both successful and unsuccessful uninstall attempts.

Testing:

    Both the install and uninstall scripts have been tested in a Docker container (Ubuntu) and on macOS.
    The scripts correctly handle sudo and non-sudo environments and ensure the binary is available in the system's PATH after installation.

Next Steps:

    Future improvements may include extending Windows support in the install script and handling any additional configuration files or logs created by GoCryptic.